### PR TITLE
Moved Amazon API variabls to separate file

### DIFF
--- a/amazon-config.default.php
+++ b/amazon-config.default.php
@@ -26,22 +26,6 @@ $store['YourAmazonStore']['secretKey'] = ''; //Secret Access Key for this store
 //Current setting is United States
 $AMAZON_SERVICE_URL = 'https://mws.amazonservices.com/';
 
-//for User-Agent header(?)
-$AMAZON_APPLICATION = 'phpAmazonMWS';
-$AMAZON_APPVERSION = '1.0';
-
-
-//Version numbers for cores
-$AMAZON_VERSION_FEEDS       = '2009-01-01';
-$AMAZON_VERSION_INBOUND     = '2010-10-01';
-$AMAZON_VERSION_INVENTORY   = '2010-10-01';
-$AMAZON_VERSION_ORDERS      = '2011-01-01';
-$AMAZON_VERSION_OUTBOUND    = '2010-10-01';
-$AMAZON_VERSION_PRODUCTS    = '2011-10-01';
-$AMAZON_VERSION_REPORTS     = '2009-01-01';
-$AMAZON_VERSION_SELLERS     = '2011-07-01';
-
-
 //Location of log file to use
 $logpath = __DIR__.'/log.txt';
 
@@ -50,59 +34,5 @@ $logfunction = '';
 
 //Turn off normal logging
 $muteLog = false;
-
-//Amazon Throttle Values in seconds
-//Do not modify unless Amazon changes the values
-//Fetching Orders
-$THROTTLE_LIMIT_ORDER = 6;
-$THROTTLE_TIME_ORDER = 60;
-//Fetching Order Lists
-$THROTTLE_LIMIT_ORDERLIST = 6;
-$THROTTLE_TIME_ORDERLIST = 60;
-//Fetching Items
-$THROTTLE_LIMIT_ITEM = 30;
-$THROTTLE_TIME_ITEM = 2;
-//Fetching Service Status
-$THROTTLE_LIMIT_STATUS = 2;
-$THROTTLE_TIME_STATUS = 300;
-//Fetching Sellers Participation
-$THROTTLE_LIMIT_SELLERS = 15;
-$THROTTLE_TIME_SELLERS = 60;
-//Anything in Inbound/Inventory/Outbound
-$THROTTLE_LIMIT_INVENTORY = 30;
-$THROTTLE_TIME_INVENTORY = 2;
-//Products
-$THROTTLE_LIMIT_PRODUCT = 20;
-$THROTTLE_TIME_PRODUCTLIST = 5;
-$THROTTLE_TIME_PRODUCTMATCH = 1;
-$THROTTLE_TIME_PRODUCTID = 4;
-$THROTTLE_TIME_PRODUCTPRICE = 2;
-//Requesting a Report
-$THROTTLE_LIMIT_REPORTREQUEST = 15;
-$THROTTLE_TIME_REPORTREQUEST = 60;
-//Fetching a Report Request List
-$THROTTLE_LIMIT_REPORTREQUESTLIST = 10;
-$THROTTLE_TIME_REPORTREQUESTLIST = 45;
-//Using a token with a report request
-$THROTTLE_LIMIT_REPORTTOKEN = 30;
-$THROTTLE_TIME_REPORTTOKEN = 2;
-//Fetching a Report List
-$THROTTLE_LIMIT_REPORTLIST = 10;
-$THROTTLE_TIME_REPORTLIST = 60;
-//Fetching a Report
-$THROTTLE_LIMIT_REPORT = 15;
-$THROTTLE_TIME_REPORT = 60;
-//Fetching a Report Request List
-$THROTTLE_LIMIT_REPORTSCHEDULE = 10;
-$THROTTLE_TIME_REPORTSCHEDULE = 45;
-//Submitting a Feed
-$THROTTLE_LIMIT_FEEDSUBMIT = 15;
-$THROTTLE_TIME_FEEDSUBMIT = 120;
-//Getting a Feed
-$THROTTLE_LIMIT_FEEDLIST = 10;
-$THROTTLE_TIME_FEEDLIST = 45;
-//Getting a Feed
-$THROTTLE_LIMIT_FEEDRESULT = 15;
-$THROTTLE_TIME_FEEDRESULT = 60;
 
 ?>

--- a/environment.php
+++ b/environment.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright 2013 CPI Group, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * These variables pertain to the inner workings of the Amazon API.
+ * The values come from Amazon and should not be modified.
+ * Otherwise, the library may not be able to connect to Amazon.
+ */
+
+//for User-Agent header(?)
+$AMAZON_APPLICATION = 'phpAmazonMWS';
+$AMAZON_APPVERSION = '1.0';
+
+//Version numbers for cores
+$AMAZON_VERSION_FEEDS       = '2009-01-01';
+$AMAZON_VERSION_INBOUND     = '2010-10-01';
+$AMAZON_VERSION_INVENTORY   = '2010-10-01';
+$AMAZON_VERSION_ORDERS      = '2011-01-01';
+$AMAZON_VERSION_OUTBOUND    = '2010-10-01';
+$AMAZON_VERSION_PRODUCTS    = '2011-10-01';
+$AMAZON_VERSION_REPORTS     = '2009-01-01';
+$AMAZON_VERSION_SELLERS     = '2011-07-01';
+
+//Amazon Throttle Values in seconds
+//Fetching Orders
+$THROTTLE_LIMIT_ORDER = 6;
+$THROTTLE_TIME_ORDER = 60;
+//Fetching Order Lists
+$THROTTLE_LIMIT_ORDERLIST = 6;
+$THROTTLE_TIME_ORDERLIST = 60;
+//Fetching Items
+$THROTTLE_LIMIT_ITEM = 30;
+$THROTTLE_TIME_ITEM = 2;
+//Fetching Service Status
+$THROTTLE_LIMIT_STATUS = 2;
+$THROTTLE_TIME_STATUS = 300;
+//Fetching Sellers Participation
+$THROTTLE_LIMIT_SELLERS = 15;
+$THROTTLE_TIME_SELLERS = 60;
+//Anything in Inbound/Inventory/Outbound
+$THROTTLE_LIMIT_INVENTORY = 30;
+$THROTTLE_TIME_INVENTORY = 2;
+//Products
+$THROTTLE_LIMIT_PRODUCT = 20;
+$THROTTLE_TIME_PRODUCTLIST = 5;
+$THROTTLE_TIME_PRODUCTMATCH = 1;
+$THROTTLE_TIME_PRODUCTID = 4;
+$THROTTLE_TIME_PRODUCTPRICE = 2;
+//Requesting a Report
+$THROTTLE_LIMIT_REPORTREQUEST = 15;
+$THROTTLE_TIME_REPORTREQUEST = 60;
+//Fetching a Report Request List
+$THROTTLE_LIMIT_REPORTREQUESTLIST = 10;
+$THROTTLE_TIME_REPORTREQUESTLIST = 45;
+//Using a token with a report request
+$THROTTLE_LIMIT_REPORTTOKEN = 30;
+$THROTTLE_TIME_REPORTTOKEN = 2;
+//Fetching a Report List
+$THROTTLE_LIMIT_REPORTLIST = 10;
+$THROTTLE_TIME_REPORTLIST = 60;
+//Fetching a Report
+$THROTTLE_LIMIT_REPORT = 15;
+$THROTTLE_TIME_REPORT = 60;
+//Fetching a Report Request List
+$THROTTLE_LIMIT_REPORTSCHEDULE = 10;
+$THROTTLE_TIME_REPORTSCHEDULE = 45;
+//Submitting a Feed
+$THROTTLE_LIMIT_FEEDSUBMIT = 15;
+$THROTTLE_TIME_FEEDSUBMIT = 120;
+//Getting a Feed
+$THROTTLE_LIMIT_FEEDLIST = 10;
+$THROTTLE_TIME_FEEDLIST = 45;
+//Getting a Feed
+$THROTTLE_LIMIT_FEEDRESULT = 15;
+$THROTTLE_TIME_FEEDRESULT = 60;
+
+?>

--- a/includes/classes/AmazonCore.php
+++ b/includes/classes/AmazonCore.php
@@ -104,6 +104,7 @@ abstract class AmazonCore{
     protected $mockFiles;
     protected $mockIndex = 0;
     protected $logpath;
+    protected $env;
     
     /**
      * AmazonCore constructor sets up key information used in all Amazon requests.
@@ -130,6 +131,7 @@ abstract class AmazonCore{
         $this->setStore($s);
         $this->setMock($mock,$m);
         
+        $this->env=__DIR__.'/../../environment.php';
         $this->options['SignatureVersion'] = 2;
         $this->options['SignatureMethod'] = 'HmacSHA256';
     }

--- a/includes/classes/AmazonFeed.php
+++ b/includes/classes/AmazonFeed.php
@@ -43,18 +43,16 @@ class AmazonFeed extends AmazonFeedsCore{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         $this->options['Action'] = 'SubmitFeed';
         
-        if(isset($THROTTLE_LIMIT_FEEDSUBMIT))
-        $this->throttleLimit = $THROTTLE_LIMIT_FEEDSUBMIT;
-        if(isset($THROTTLE_TIME_FEEDSUBMIT))
-        $this->throttleTime = $THROTTLE_TIME_FEEDSUBMIT;
+        if(isset($THROTTLE_LIMIT_FEEDSUBMIT)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_FEEDSUBMIT;
+        }
+        if(isset($THROTTLE_TIME_FEEDSUBMIT)) {
+            $this->throttleTime = $THROTTLE_TIME_FEEDSUBMIT;
+        }
         $this->throttleGroup = 'SubmitFeed';
     }
     
@@ -213,12 +211,9 @@ class AmazonFeed extends AmazonFeedsCore{
         } else if ($s == 'false' || (!$s && is_bool($s))){
             $this->log("Purge mode deactivated.");
             $this->options['PurgeAndReplace'] = 'false';
-            if (file_exists($this->config)){
-                include($this->config);
-                if(isset($THROTTLE_TIME_FEEDSUBMIT))
+            include($this->env);
+            if(isset($THROTTLE_TIME_FEEDSUBMIT)) {
                 $this->throttleTime = $THROTTLE_TIME_FEEDSUBMIT;
-            } else {
-                return false;
             }
         } else {
             return false;

--- a/includes/classes/AmazonFeedList.php
+++ b/includes/classes/AmazonFeedList.php
@@ -48,16 +48,14 @@ class AmazonFeedList extends AmazonFeedsCore implements Iterator{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
-        if(isset($THROTTLE_LIMIT_FEEDLIST))
-        $this->throttleLimit = $THROTTLE_LIMIT_FEEDLIST;
-        if(isset($THROTTLE_TIME_FEEDLIST))
-        $this->throttleTime = $THROTTLE_TIME_FEEDLIST;
+        if(isset($THROTTLE_LIMIT_FEEDLIST)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_FEEDLIST;
+        }
+        if(isset($THROTTLE_TIME_FEEDLIST)) {
+            $this->throttleTime = $THROTTLE_TIME_FEEDLIST;
+        }
     }
     
     /**
@@ -308,13 +306,15 @@ class AmazonFeedList extends AmazonFeedsCore implements Iterator{
      * parameters will be removed.
      */
     protected function prepareToken(){
-        include($this->config);
+        include($this->env);
         if ($this->tokenFlag && $this->tokenUseFlag){
             $this->options['Action'] = 'GetFeedSubmissionListByNextToken';
-            if(isset($THROTTLE_LIMIT_REPORTTOKEN))
-            $this->throttleLimit = $THROTTLE_LIMIT_REPORTTOKEN;
-            if(isset($THROTTLE_TIME_REPORTTOKEN))
-            $this->throttleTime = $THROTTLE_TIME_REPORTTOKEN;
+            if(isset($THROTTLE_LIMIT_REPORTTOKEN)) {
+                $this->throttleLimit = $THROTTLE_LIMIT_REPORTTOKEN;
+            }
+            if(isset($THROTTLE_TIME_REPORTTOKEN)) {
+                $this->throttleTime = $THROTTLE_TIME_REPORTTOKEN;
+            }
             $this->throttleGroup = 'GetFeedSubmissionListByNextToken';
             $this->resetFeedTypes();
             $this->resetFeedStatuses();
@@ -323,10 +323,12 @@ class AmazonFeedList extends AmazonFeedsCore implements Iterator{
             unset($this->options['MaxCount']);
         } else {
             $this->options['Action'] = 'GetFeedSubmissionList';
-            if(isset($THROTTLE_LIMIT_FEEDLIST))
-            $this->throttleLimit = $THROTTLE_LIMIT_FEEDLIST;
-            if(isset($THROTTLE_TIME_FEEDLIST))
-            $this->throttleTime = $THROTTLE_TIME_FEEDLIST;
+            if(isset($THROTTLE_LIMIT_FEEDLIST)) {
+                $this->throttleLimit = $THROTTLE_LIMIT_FEEDLIST;
+            }
+            if(isset($THROTTLE_TIME_FEEDLIST)) {
+                $this->throttleTime = $THROTTLE_TIME_FEEDLIST;
+            }
             $this->throttleGroup = 'GetFeedSubmissionList';
             unset($this->options['NextToken']);
             $this->feedList = array();
@@ -405,10 +407,12 @@ class AmazonFeedList extends AmazonFeedsCore implements Iterator{
      */
     protected function prepareCount(){
         $this->options['Action'] = 'GetFeedSubmissionCount';
-        if(isset($THROTTLE_LIMIT_FEEDLIST))
-        $this->throttleLimit = $THROTTLE_LIMIT_FEEDLIST;
-        if(isset($THROTTLE_TIME_FEEDLIST))
-        $this->throttleTime = $THROTTLE_TIME_FEEDLIST;
+        if(isset($THROTTLE_LIMIT_FEEDLIST)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_FEEDLIST;
+        }
+        if(isset($THROTTLE_TIME_FEEDLIST)) {
+            $this->throttleTime = $THROTTLE_TIME_FEEDLIST;
+        }
         $this->throttleGroup = 'GetFeedSubmissionCount';
         $this->resetFeedIds();
         unset($this->options['MaxCount']);
@@ -457,12 +461,14 @@ class AmazonFeedList extends AmazonFeedsCore implements Iterator{
      * feed statuses, max count, and token.
      */
     protected function prepareCancel(){
-        include($this->config);
+        include($this->env);
         $this->options['Action'] = 'CancelFeedSubmissions';
-        if(isset($THROTTLE_LIMIT_FEEDLIST))
-        $this->throttleLimit = $THROTTLE_LIMIT_FEEDLIST;
-        if(isset($THROTTLE_TIME_FEEDLIST))
-        $this->throttleTime = $THROTTLE_TIME_FEEDLIST;
+        if(isset($THROTTLE_LIMIT_FEEDLIST)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_FEEDLIST;
+        }
+        if(isset($THROTTLE_TIME_FEEDLIST)) {
+            $this->throttleTime = $THROTTLE_TIME_FEEDLIST;
+        }
         $this->throttleGroup = 'CancelFeedSubmissions';
         unset($this->options['MaxCount']);
         unset($this->options['NextToken']);

--- a/includes/classes/AmazonFeedResult.php
+++ b/includes/classes/AmazonFeedResult.php
@@ -44,11 +44,7 @@ class AmazonFeedResult extends AmazonFeedsCore{
      */
     public function __construct($s, $id = null, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if($id){
             $this->options['FeedSubmissionId'] = $id;
@@ -56,10 +52,12 @@ class AmazonFeedResult extends AmazonFeedsCore{
         
         $this->options['Action'] = 'GetFeedSubmissionResult';
         
-        if(isset($THROTTLE_LIMIT_FEEDRESULT))
-        $this->throttleLimit = $THROTTLE_LIMIT_FEEDRESULT;
-        if(isset($THROTTLE_TIME_FEEDRESULT))
-        $this->throttleTime = $THROTTLE_TIME_FEEDRESULT;
+        if(isset($THROTTLE_LIMIT_FEEDRESULT)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_FEEDRESULT;
+        }
+        if(isset($THROTTLE_TIME_FEEDRESULT)) {
+            $this->throttleTime = $THROTTLE_TIME_FEEDRESULT;
+        }
         $this->throttleGroup = 'GetFeedSubmissionResult';
     }
     

--- a/includes/classes/AmazonFeedsCore.php
+++ b/includes/classes/AmazonFeedsCore.php
@@ -38,15 +38,12 @@ abstract class AmazonFeedsCore extends AmazonCore{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         $this->urlbranch = '';
-        if(isset($AMAZON_VERSION_FEEDS))
-        $this->options['Version'] = $AMAZON_VERSION_FEEDS;
+        if(isset($AMAZON_VERSION_FEEDS)) {
+            $this->options['Version'] = $AMAZON_VERSION_FEEDS;
+        }
     }
 }
 ?>

--- a/includes/classes/AmazonInboundCore.php
+++ b/includes/classes/AmazonInboundCore.php
@@ -38,11 +38,7 @@ abstract class AmazonInboundCore extends AmazonCore{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if(isset($AMAZON_VERSION_INBOUND)){
             $this->urlbranch = 'FulfillmentInboundShipment/'.$AMAZON_VERSION_INBOUND;
@@ -50,10 +46,12 @@ abstract class AmazonInboundCore extends AmazonCore{
         }
         
         
-        if(isset($THROTTLE_LIMIT_INVENTORY))
-        $this->throttleLimit = $THROTTLE_LIMIT_INVENTORY;
-        if(isset($THROTTLE_TIME_INVENTORY))
-        $this->throttleTime = $THROTTLE_TIME_INVENTORY;
+        if(isset($THROTTLE_LIMIT_INVENTORY)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_INVENTORY;
+        }
+        if(isset($THROTTLE_TIME_INVENTORY)) {
+            $this->throttleTime = $THROTTLE_TIME_INVENTORY;
+        }
         $this->throttleGroup = 'Inventory';
     }
 }

--- a/includes/classes/AmazonInventoryCore.php
+++ b/includes/classes/AmazonInventoryCore.php
@@ -38,21 +38,19 @@ abstract class AmazonInventoryCore extends AmazonCore{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if(isset($AMAZON_VERSION_INVENTORY)){
             $this->urlbranch = 'FulfillmentInventory/'.$AMAZON_VERSION_INVENTORY;
             $this->options['Version'] = $AMAZON_VERSION_INVENTORY;
         }
         
-        if(isset($THROTTLE_LIMIT_INVENTORY))
-        $this->throttleLimit = $THROTTLE_LIMIT_INVENTORY;
-        if(isset($THROTTLE_TIME_INVENTORY))
-        $this->throttleTime = $THROTTLE_TIME_INVENTORY;
+        if(isset($THROTTLE_LIMIT_INVENTORY)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_INVENTORY;
+        }
+        if(isset($THROTTLE_TIME_INVENTORY)) {
+            $this->throttleTime = $THROTTLE_TIME_INVENTORY;
+        }
         $this->throttleGroup = 'Inventory';
     }
 }

--- a/includes/classes/AmazonOrder.php
+++ b/includes/classes/AmazonOrder.php
@@ -44,11 +44,7 @@ class AmazonOrder extends AmazonOrderCore{
      */
     public function __construct($s, $id = null, $data = null, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if($id){
             $this->setOrderId($id);
@@ -59,10 +55,12 @@ class AmazonOrder extends AmazonOrderCore{
         
         $this->options['Action'] = 'GetOrder';
         
-        if(isset($THROTTLE_LIMIT_ORDER))
-        $this->throttleLimit = $THROTTLE_LIMIT_ORDER;
-        if(isset($THROTTLE_TIME_ORDER))
-        $this->throttleTime = $THROTTLE_TIME_ORDER;
+        if(isset($THROTTLE_LIMIT_ORDER)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_ORDER;
+        }
+        if(isset($THROTTLE_TIME_ORDER)) {
+            $this->throttleTime = $THROTTLE_TIME_ORDER;
+        }
         $this->throttleGroup = 'GetOrder';
     }
     

--- a/includes/classes/AmazonOrderCore.php
+++ b/includes/classes/AmazonOrderCore.php
@@ -38,11 +38,7 @@ abstract class AmazonOrderCore extends AmazonCore{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if(isset($AMAZON_VERSION_ORDERS)){
             $this->urlbranch = 'Orders/'.$AMAZON_VERSION_ORDERS;

--- a/includes/classes/AmazonOrderItemList.php
+++ b/includes/classes/AmazonOrderItemList.php
@@ -47,21 +47,19 @@ class AmazonOrderItemList extends AmazonOrderCore implements Iterator{
      */
     public function __construct($s, $id=null, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         
         if (!is_null($id)){
             $this->setOrderId($id);
         }
         
-        if(isset($THROTTLE_LIMIT_ITEM))
-        $this->throttleLimit = $THROTTLE_LIMIT_ITEM;
-        if(isset($THROTTLE_TIME_ITEM))
-        $this->throttleTime = $THROTTLE_TIME_ITEM;
+        if(isset($THROTTLE_LIMIT_ITEM)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_ITEM;
+        }
+        if(isset($THROTTLE_TIME_ITEM)) {
+            $this->throttleTime = $THROTTLE_TIME_ITEM;
+        }
         $this->throttleGroup = 'ListOrderItems';
     }
     

--- a/includes/classes/AmazonOrderList.php
+++ b/includes/classes/AmazonOrderList.php
@@ -45,6 +45,7 @@ class AmazonOrderList extends AmazonOrderCore implements Iterator{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
+        include($this->env);
         if (file_exists($this->config)){
             include($this->config);
         } else {
@@ -57,10 +58,12 @@ class AmazonOrderList extends AmazonOrderCore implements Iterator{
             $this->log("Marketplace ID is missing",'Urgent');
         }
         
-        if(isset($THROTTLE_LIMIT_ORDERLIST))
-        $this->throttleLimit = $THROTTLE_LIMIT_ORDERLIST;
-        if(isset($THROTTLE_TIME_ORDERLIST))
-        $this->throttleTime = $THROTTLE_TIME_ORDERLIST;
+        if(isset($THROTTLE_LIMIT_ORDERLIST)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_ORDERLIST;
+        }
+        if(isset($THROTTLE_TIME_ORDERLIST)) {
+            $this->throttleTime = $THROTTLE_TIME_ORDERLIST;
+        }
         $this->throttleGroup = 'ListOrders';
     }
     

--- a/includes/classes/AmazonOrderSet.php
+++ b/includes/classes/AmazonOrderSet.php
@@ -47,21 +47,19 @@ class AmazonOrderSet extends AmazonOrderCore implements Iterator{
     public function __construct($s, $o = null, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
         $this->i = 0;
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if($o){
             $this->setOrderIds($o);
         }
         
         $this->options['Action'] = 'GetOrder';
-        if(isset($THROTTLE_LIMIT_ORDER))
-        $this->throttleLimit = $THROTTLE_LIMIT_ORDER;
-        if(isset($THROTTLE_TIME_ORDER))
-        $this->throttleTime = $THROTTLE_TIME_ORDER;
+        if(isset($THROTTLE_LIMIT_ORDER)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_ORDER;
+        }
+        if(isset($THROTTLE_TIME_ORDER)) {
+            $this->throttleTime = $THROTTLE_TIME_ORDER;
+        }
         $this->throttleGroup = 'GetOrder';
     }
     

--- a/includes/classes/AmazonOutboundCore.php
+++ b/includes/classes/AmazonOutboundCore.php
@@ -38,11 +38,7 @@ abstract class AmazonOutboundCore extends AmazonCore{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if(isset($AMAZON_VERSION_OUTBOUND)){
             $this->urlbranch = 'FulfillmentOutboundShipment/'.$AMAZON_VERSION_OUTBOUND;
@@ -50,10 +46,12 @@ abstract class AmazonOutboundCore extends AmazonCore{
         }
         
         
-        if(isset($THROTTLE_LIMIT_INVENTORY))
-        $this->throttleLimit = $THROTTLE_LIMIT_INVENTORY;
-        if(isset($THROTTLE_TIME_INVENTORY))
-        $this->throttleTime = $THROTTLE_TIME_INVENTORY;
+        if(isset($THROTTLE_LIMIT_INVENTORY)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_INVENTORY;
+        }
+        if(isset($THROTTLE_TIME_INVENTORY)) {
+            $this->throttleTime = $THROTTLE_TIME_INVENTORY;
+        }
         $this->throttleGroup = 'Inventory';
     }
 }

--- a/includes/classes/AmazonParticipationList.php
+++ b/includes/classes/AmazonParticipationList.php
@@ -45,16 +45,14 @@ class AmazonParticipationList extends AmazonSellersCore{
      */
     public function __construct($s, $mock = false, $m = null, $config = null) {
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
-        if(isset($THROTTLE_LIMIT_SELLERS))
-        $this->throttleLimit = $THROTTLE_LIMIT_SELLERS;
-        if(isset($THROTTLE_TIME_SELLERS))
-        $this->throttleTime = $THROTTLE_TIME_SELLERS;
+        if(isset($THROTTLE_LIMIT_SELLERS)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_SELLERS;
+        }
+        if(isset($THROTTLE_TIME_SELLERS)) {
+            $this->throttleTime = $THROTTLE_TIME_SELLERS;
+        }
         $this->throttleGroup = 'ParticipationList';
     }
     

--- a/includes/classes/AmazonProductInfo.php
+++ b/includes/classes/AmazonProductInfo.php
@@ -205,9 +205,10 @@ class AmazonProductInfo extends AmazonProductsCore{
      * ItemCondition and ExcludeMe.
      */
     protected function prepareCompetitive(){
-        include($this->config);
-        if(isset($THROTTLE_TIME_PRODUCTPRICE))
-        $this->throttleTime = $THROTTLE_TIME_PRODUCTPRICE;
+        include($this->env);
+        if(isset($THROTTLE_TIME_PRODUCTPRICE)) {
+            $this->throttleTime = $THROTTLE_TIME_PRODUCTPRICE;
+        }
         $this->throttleGroup = 'GetCompetitivePricing';
         unset($this->options['ExcludeMe']);
         unset($this->options['ItemCondition']);
@@ -263,9 +264,10 @@ class AmazonProductInfo extends AmazonProductsCore{
      * This changes key options for using <i>fetchLowestOffer</i>.
      */
     protected function prepareLowest(){
-        include($this->config);
-        if(isset($THROTTLE_TIME_PRODUCTPRICE))
-        $this->throttleTime = $THROTTLE_TIME_PRODUCTPRICE;
+        include($this->env);
+        if(isset($THROTTLE_TIME_PRODUCTPRICE)) {
+            $this->throttleTime = $THROTTLE_TIME_PRODUCTPRICE;
+        }
         $this->throttleGroup = 'GetLowestOfferListings';
         if (array_key_exists('SellerSKUList.SellerSKU.1',$this->options)){
             $this->options['Action'] = 'GetLowestOfferListingsForSKU';
@@ -321,9 +323,10 @@ class AmazonProductInfo extends AmazonProductsCore{
      * the ExcludeMe parameter will be removed.
      */
     protected function prepareMyPrice(){
-        include($this->config);
-        if(isset($THROTTLE_TIME_PRODUCTPRICE))
-        $this->throttleTime = $THROTTLE_TIME_PRODUCTPRICE;
+        include($this->env);
+        if(isset($THROTTLE_TIME_PRODUCTPRICE)) {
+            $this->throttleTime = $THROTTLE_TIME_PRODUCTPRICE;
+        }
         $this->throttleGroup = 'GetMyPrice';
         unset($this->options['ExcludeMe']);
         if (array_key_exists('SellerSKUList.SellerSKU.1',$this->options)){
@@ -380,9 +383,10 @@ class AmazonProductInfo extends AmazonProductsCore{
      * ItemCondition and ExcludeMe.
      */
     protected function prepareCategories(){
-        include($this->config);
-        if(isset($THROTTLE_TIME_PRODUCTLIST))
-        $this->throttleTime = $THROTTLE_TIME_PRODUCTLIST;
+        include($this->env);
+        if(isset($THROTTLE_TIME_PRODUCTLIST)) {
+            $this->throttleTime = $THROTTLE_TIME_PRODUCTLIST;
+        }
         $this->throttleGroup = 'GetProductCategories';
         unset($this->options['ExcludeMe']);
         unset($this->options['ItemCondition']);

--- a/includes/classes/AmazonProductList.php
+++ b/includes/classes/AmazonProductList.php
@@ -40,16 +40,13 @@ class AmazonProductList extends AmazonProductsCore implements Iterator{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         $this->options['Action'] = 'GetMatchingProductForId';
         
-        if(isset($THROTTLE_TIME_PRODUCTLIST))
-        $this->throttleTime = $THROTTLE_TIME_PRODUCTLIST;
+        if(isset($THROTTLE_TIME_PRODUCTLIST)) {
+            $this->throttleTime = $THROTTLE_TIME_PRODUCTLIST;
+        }
         $this->throttleGroup = 'GetMatchingProductForId';
     }
     

--- a/includes/classes/AmazonProductSearch.php
+++ b/includes/classes/AmazonProductSearch.php
@@ -44,11 +44,7 @@ class AmazonProductSearch extends AmazonProductsCore{
      */
     public function __construct($s, $q = null, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if($q){
             $this->setQuery($q);
@@ -56,8 +52,9 @@ class AmazonProductSearch extends AmazonProductsCore{
         
         $this->options['Action'] = 'ListMatchingProducts';
         
-        if(isset($THROTTLE_TIME_PRODUCTMATCH))
-        $this->throttleTime = $THROTTLE_TIME_PRODUCTMATCH;
+        if(isset($THROTTLE_TIME_PRODUCTMATCH)) {
+            $this->throttleTime = $THROTTLE_TIME_PRODUCTMATCH;
+        }
         $this->throttleGroup = 'ListMatchingProducts';
     }
     

--- a/includes/classes/AmazonProductsCore.php
+++ b/includes/classes/AmazonProductsCore.php
@@ -41,6 +41,7 @@ abstract class AmazonProductsCore extends AmazonCore{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
+        include($this->env);
         if (file_exists($this->config)){
             include($this->config);
         } else {
@@ -59,8 +60,9 @@ abstract class AmazonProductsCore extends AmazonCore{
             $this->log("Marketplace ID is missing",'Urgent');
         }
         
-        if(isset($THROTTLE_LIMIT_PRODUCT))
-        $this->throttleLimit = $THROTTLE_LIMIT_PRODUCT;
+        if(isset($THROTTLE_LIMIT_PRODUCT)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_PRODUCT;
+        }
     }
     
     /**

--- a/includes/classes/AmazonReport.php
+++ b/includes/classes/AmazonReport.php
@@ -43,11 +43,7 @@ class AmazonReport extends AmazonReportsCore{
      */
     public function __construct($s, $id = null, $mock = false, $m = null, $config = null) {
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if($id){
             $this->setReportId($id);
@@ -55,10 +51,12 @@ class AmazonReport extends AmazonReportsCore{
         
         $this->options['Action'] = 'GetReport';
         
-        if(isset($THROTTLE_LIMIT_REPORT))
-        $this->throttleLimit = $THROTTLE_LIMIT_REPORT;
-        if(isset($THROTTLE_TIME_REPORT))
-        $this->throttleTime = $THROTTLE_TIME_REPORT;
+        if(isset($THROTTLE_LIMIT_REPORT)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_REPORT;
+        }
+        if(isset($THROTTLE_TIME_REPORT)) {
+            $this->throttleTime = $THROTTLE_TIME_REPORT;
+        }
     }
     
     /**

--- a/includes/classes/AmazonReportAcknowledger.php
+++ b/includes/classes/AmazonReportAcknowledger.php
@@ -46,11 +46,7 @@ class AmazonReportAcknowledger extends AmazonReportsCore implements Iterator{
      */
     public function __construct($s, $id = null, $mock = false, $m = null, $config = null) {
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if ($id){
             $this->setReportIds($id);
@@ -58,10 +54,12 @@ class AmazonReportAcknowledger extends AmazonReportsCore implements Iterator{
         
         $this->options['Action'] = 'UpdateReportAcknowledgements';
         
-        if(isset($THROTTLE_LIMIT_REPORTSCHEDULE))
-        $this->throttleLimit = $THROTTLE_LIMIT_REPORTSCHEDULE;
-        if(isset($THROTTLE_TIME_REPORTSCHEDULE))
-        $this->throttleTime = $THROTTLE_TIME_REPORTSCHEDULE;
+        if(isset($THROTTLE_LIMIT_REPORTSCHEDULE)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_REPORTSCHEDULE;
+        }
+        if(isset($THROTTLE_TIME_REPORTSCHEDULE)) {
+            $this->throttleTime = $THROTTLE_TIME_REPORTSCHEDULE;
+        }
         $this->throttleGroup = 'UpdateReportAcknowledgements';
     }
     

--- a/includes/classes/AmazonReportList.php
+++ b/includes/classes/AmazonReportList.php
@@ -45,16 +45,14 @@ class AmazonReportList extends AmazonReportsCore implements Iterator{
      */
     public function __construct($s, $mock = false, $m = null, $config = null) {
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
-        if(isset($THROTTLE_LIMIT_REPORTLIST))
-        $this->throttleLimit = $THROTTLE_LIMIT_REPORTLIST;
-        if(isset($THROTTLE_TIME_REPORTLIST))
-        $this->throttleTime = $THROTTLE_TIME_REPORTLIST;
+        if(isset($THROTTLE_LIMIT_REPORTLIST)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_REPORTLIST;
+        }
+        if(isset($THROTTLE_TIME_REPORTLIST)) {
+            $this->throttleTime = $THROTTLE_TIME_REPORTLIST;
+        }
     }
     
     /**
@@ -286,13 +284,15 @@ class AmazonReportList extends AmazonReportsCore implements Iterator{
      * parameters will be removed.
      */
     protected function prepareToken(){
-        include($this->config);
+        include($this->env);
         if ($this->tokenFlag && $this->tokenUseFlag){
             $this->options['Action'] = 'GetReportListByNextToken';
-            if(isset($THROTTLE_LIMIT_REPORTTOKEN))
-            $this->throttleLimit = $THROTTLE_LIMIT_REPORTTOKEN;
-            if(isset($THROTTLE_TIME_REPORTTOKEN))
-            $this->throttleTime = $THROTTLE_TIME_REPORTTOKEN;
+            if(isset($THROTTLE_LIMIT_REPORTTOKEN)) {
+                $this->throttleLimit = $THROTTLE_LIMIT_REPORTTOKEN;
+            }
+            if(isset($THROTTLE_TIME_REPORTTOKEN)) {
+                $this->throttleTime = $THROTTLE_TIME_REPORTTOKEN;
+            }
             $this->throttleGroup = 'GetReportListByNextToken';
             $this->resetRequestIds();
             $this->resetReportTypes();
@@ -301,10 +301,12 @@ class AmazonReportList extends AmazonReportsCore implements Iterator{
             unset($this->options['Acknowledged']);
         } else {
             $this->options['Action'] = 'GetReportList';
-            if(isset($THROTTLE_LIMIT_REPORTLIST))
-            $this->throttleLimit = $THROTTLE_LIMIT_REPORTLIST;
-            if(isset($THROTTLE_TIME_REPORTLIST))
-            $this->throttleTime = $THROTTLE_TIME_REPORTLIST;
+            if(isset($THROTTLE_LIMIT_REPORTLIST)) {
+                $this->throttleLimit = $THROTTLE_LIMIT_REPORTLIST;
+            }
+            if(isset($THROTTLE_TIME_REPORTLIST)) {
+                $this->throttleTime = $THROTTLE_TIME_REPORTLIST;
+            }
             $this->throttleGroup = 'GetReportList';
             unset($this->options['NextToken']);
             $this->reportList = array();
@@ -379,12 +381,14 @@ class AmazonReportList extends AmazonReportsCore implements Iterator{
      * request IDs, max count, and token.
      */
     protected function prepareCount(){
-        include($this->config);
+        include($this->env);
         $this->options['Action'] = 'GetReportCount';
-        if(isset($THROTTLE_LIMIT_REPORTREQUESTLIST))
-        $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUESTLIST;
-        if(isset($THROTTLE_TIME_REPORTREQUESTLIST))
-        $this->throttleTime = $THROTTLE_TIME_REPORTREQUESTLIST;
+        if(isset($THROTTLE_LIMIT_REPORTREQUESTLIST)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUESTLIST;
+        }
+        if(isset($THROTTLE_TIME_REPORTREQUESTLIST)) {
+            $this->throttleTime = $THROTTLE_TIME_REPORTREQUESTLIST;
+        }
         $this->throttleGroup = 'GetReportCount';
         unset($this->options['NextToken']);
         unset($this->options['MaxCount']);

--- a/includes/classes/AmazonReportRequest.php
+++ b/includes/classes/AmazonReportRequest.php
@@ -40,18 +40,16 @@ class AmazonReportRequest extends AmazonReportsCore{
      */
     public function __construct($s, $mock = false, $m = null, $config = null) {
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         $this->options['Action'] = 'RequestReport';
         
-        if(isset($THROTTLE_LIMIT_REPORTREQUEST))
-        $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUEST;
-        if(isset($THROTTLE_TIME_REPORTREQUEST))
-        $this->throttleTime = $THROTTLE_TIME_REPORTREQUEST;
+        if(isset($THROTTLE_LIMIT_REPORTREQUEST)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUEST;
+        }
+        if(isset($THROTTLE_TIME_REPORTREQUEST)) {
+            $this->throttleTime = $THROTTLE_TIME_REPORTREQUEST;
+        }
         $this->throttleGroup = 'RequestReport';
     }
     

--- a/includes/classes/AmazonReportRequestList.php
+++ b/includes/classes/AmazonReportRequestList.php
@@ -47,16 +47,14 @@ class AmazonReportRequestList extends AmazonReportsCore implements Iterator{
      */
     public function __construct($s, $mock = false, $m = null, $config = null) {
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
-        if(isset($THROTTLE_LIMIT_REPORTREQUESTLIST))
-        $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUESTLIST;
-        if(isset($THROTTLE_TIME_REPORTREQUESTLIST))
-        $this->throttleTime = $THROTTLE_TIME_REPORTREQUESTLIST;
+        if(isset($THROTTLE_LIMIT_REPORTREQUESTLIST)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUESTLIST;
+        }
+        if(isset($THROTTLE_TIME_REPORTREQUESTLIST)) {
+            $this->throttleTime = $THROTTLE_TIME_REPORTREQUESTLIST;
+        }
     }
     
     /**
@@ -303,13 +301,15 @@ class AmazonReportRequestList extends AmazonReportsCore implements Iterator{
      * parameters will be removed.
      */
     protected function prepareToken(){
-        include($this->config);
+        include($this->env);
         if ($this->tokenFlag && $this->tokenUseFlag){
             $this->options['Action'] = 'GetReportRequestListByNextToken';
-        if(isset($THROTTLE_LIMIT_REPORTTOKEN))
-            $this->throttleLimit = $THROTTLE_LIMIT_REPORTTOKEN;
-        if(isset($THROTTLE_TIME_REPORTTOKEN))
-            $this->throttleTime = $THROTTLE_TIME_REPORTTOKEN;
+            if(isset($THROTTLE_LIMIT_REPORTTOKEN)) {
+                $this->throttleLimit = $THROTTLE_LIMIT_REPORTTOKEN;
+            }
+            if(isset($THROTTLE_TIME_REPORTTOKEN)) {
+                $this->throttleTime = $THROTTLE_TIME_REPORTTOKEN;
+            }
             $this->throttleGroup = 'GetReportRequestListByNextToken';
             $this->resetRequestIds();
             $this->resetReportTypes();
@@ -319,10 +319,12 @@ class AmazonReportRequestList extends AmazonReportsCore implements Iterator{
             unset($this->options['RequestedToDate']);
         } else {
             $this->options['Action'] = 'GetReportRequestList';
-        if(isset($THROTTLE_LIMIT_REPORTREQUESTLIST))
-            $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUESTLIST;
-        if(isset($THROTTLE_TIME_REPORTREQUESTLIST))
-            $this->throttleTime = $THROTTLE_TIME_REPORTREQUESTLIST;
+            if(isset($THROTTLE_LIMIT_REPORTREQUESTLIST)) {
+                $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUESTLIST;
+            }
+            if(isset($THROTTLE_TIME_REPORTREQUESTLIST)) {
+                $this->throttleTime = $THROTTLE_TIME_REPORTREQUESTLIST;
+            }
             $this->throttleGroup = 'GetReportRequestList';
             unset($this->options['NextToken']);
             $this->reportList = array();
@@ -339,12 +341,14 @@ class AmazonReportRequestList extends AmazonReportsCore implements Iterator{
      * max count and token.
      */
     protected function prepareCancel(){
-        include($this->config);
+        include($this->env);
         $this->options['Action'] = 'CancelReportRequests';
-        if(isset($THROTTLE_LIMIT_REPORTREQUESTLIST))
-        $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUESTLIST;
-        if(isset($THROTTLE_TIME_REPORTREQUESTLIST))
-        $this->throttleTime = $THROTTLE_TIME_REPORTREQUESTLIST;
+        if(isset($THROTTLE_LIMIT_REPORTREQUESTLIST)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUESTLIST;
+        }
+        if(isset($THROTTLE_TIME_REPORTREQUESTLIST)) {
+            $this->throttleTime = $THROTTLE_TIME_REPORTREQUESTLIST;
+        }
         $this->throttleGroup = 'CancelReportRequests';
         unset($this->options['MaxCount']);
         unset($this->options['NextToken']);
@@ -461,12 +465,14 @@ class AmazonReportRequestList extends AmazonReportsCore implements Iterator{
      * request IDs, max count, and token.
      */
     protected function prepareCount(){
-        include($this->config);
+        include($this->env);
         $this->options['Action'] = 'GetReportRequestCount';
-        if(isset($THROTTLE_LIMIT_REPORTREQUESTLIST))
-        $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUESTLIST;
-        if(isset($THROTTLE_TIME_REPORTREQUESTLIST))
-        $this->throttleTime = $THROTTLE_TIME_REPORTREQUESTLIST;
+        if(isset($THROTTLE_LIMIT_REPORTREQUESTLIST)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_REPORTREQUESTLIST;
+        }
+        if(isset($THROTTLE_TIME_REPORTREQUESTLIST)) {
+            $this->throttleTime = $THROTTLE_TIME_REPORTREQUESTLIST;
+        }
         $this->throttleGroup = 'GetReportRequestCount';
         unset($this->options['NextToken']);
         unset($this->options['MaxCount']);

--- a/includes/classes/AmazonReportScheduleList.php
+++ b/includes/classes/AmazonReportScheduleList.php
@@ -47,16 +47,14 @@ class AmazonReportScheduleList extends AmazonReportsCore implements Iterator{
      */
     public function __construct($s, $mock = false, $m = null, $config = null) {
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
-        if(isset($THROTTLE_LIMIT_REPORTSCHEDULE))
-        $this->throttleLimit = $THROTTLE_LIMIT_REPORTSCHEDULE;
-        if(isset($THROTTLE_TIME_REPORTSCHEDULE))
-        $this->throttleTime = $THROTTLE_TIME_REPORTSCHEDULE;
+        if(isset($THROTTLE_LIMIT_REPORTSCHEDULE)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_REPORTSCHEDULE;
+        }
+        if(isset($THROTTLE_TIME_REPORTSCHEDULE)) {
+            $this->throttleTime = $THROTTLE_TIME_REPORTSCHEDULE;
+        }
     }
     
     /**
@@ -176,21 +174,25 @@ class AmazonReportScheduleList extends AmazonReportsCore implements Iterator{
      * parameters will be removed.
      */
     protected function prepareToken(){
-        include($this->config);
+        include($this->env);
         if ($this->tokenFlag && $this->tokenUseFlag){
             $this->options['Action'] = 'GetReportScheduleListByNextToken';
-        if(isset($THROTTLE_LIMIT_REPORTTOKEN))
-            $this->throttleLimit = $THROTTLE_LIMIT_REPORTTOKEN;
-        if(isset($THROTTLE_TIME_REPORTTOKEN))
-            $this->throttleTime = $THROTTLE_TIME_REPORTTOKEN;
+            if(isset($THROTTLE_LIMIT_REPORTTOKEN)) {
+                $this->throttleLimit = $THROTTLE_LIMIT_REPORTTOKEN;
+            }
+            if(isset($THROTTLE_TIME_REPORTTOKEN)) {
+                $this->throttleTime = $THROTTLE_TIME_REPORTTOKEN;
+            }
             $this->throttleGroup = 'GetReportScheduleListByNextToken';
             $this->resetReportTypes();
         } else {
             $this->options['Action'] = 'GetReportScheduleList';
-        if(isset($THROTTLE_LIMIT_REPORTSCHEDULE))
-            $this->throttleLimit = $THROTTLE_LIMIT_REPORTSCHEDULE;
-        if(isset($THROTTLE_TIME_REPORTSCHEDULE))
-            $this->throttleTime = $THROTTLE_TIME_REPORTSCHEDULE;
+            if(isset($THROTTLE_LIMIT_REPORTSCHEDULE)) {
+                $this->throttleLimit = $THROTTLE_LIMIT_REPORTSCHEDULE;
+            }
+            if(isset($THROTTLE_TIME_REPORTSCHEDULE)) {
+                $this->throttleTime = $THROTTLE_TIME_REPORTSCHEDULE;
+            }
             $this->throttleGroup = 'GetReportScheduleList';
             unset($this->options['NextToken']);
             $this->scheduleList = array();
@@ -263,12 +265,14 @@ class AmazonReportScheduleList extends AmazonReportsCore implements Iterator{
      * request IDs, max count, and token.
      */
     protected function prepareCount(){
-        include($this->config);
+        include($this->env);
         $this->options['Action'] = 'GetReportScheduleCount';
-        if(isset($THROTTLE_LIMIT_REPORTSCHEDULE))
-        $this->throttleLimit = $THROTTLE_LIMIT_REPORTSCHEDULE;
-        if(isset($THROTTLE_TIME_REPORTSCHEDULE))
-        $this->throttleTime = $THROTTLE_TIME_REPORTSCHEDULE;
+        if(isset($THROTTLE_LIMIT_REPORTSCHEDULE)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_REPORTSCHEDULE;
+        }
+        if(isset($THROTTLE_TIME_REPORTSCHEDULE)) {
+            $this->throttleTime = $THROTTLE_TIME_REPORTSCHEDULE;
+        }
         $this->throttleGroup = 'GetReportScheduleCount';
         unset($this->options['NextToken']);
     }

--- a/includes/classes/AmazonReportScheduleManager.php
+++ b/includes/classes/AmazonReportScheduleManager.php
@@ -45,18 +45,16 @@ class AmazonReportScheduleManager extends AmazonReportsCore implements Iterator{
      */
     public function __construct($s, $mock = false, $m = null, $config = null) {
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         $this->options['Action'] = 'ManageReportSchedule';
         
-        if(isset($THROTTLE_LIMIT_REPORTSCHEDULE))
-        $this->throttleLimit = $THROTTLE_LIMIT_REPORTSCHEDULE;
-        if(isset($THROTTLE_TIME_REPORTSCHEDULE))
-        $this->throttleTime = $THROTTLE_TIME_REPORTSCHEDULE;
+        if(isset($THROTTLE_LIMIT_REPORTSCHEDULE)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_REPORTSCHEDULE;
+        }
+        if(isset($THROTTLE_TIME_REPORTSCHEDULE)) {
+            $this->throttleTime = $THROTTLE_TIME_REPORTSCHEDULE;
+        }
     }
     
     /**

--- a/includes/classes/AmazonReportsCore.php
+++ b/includes/classes/AmazonReportsCore.php
@@ -38,15 +38,12 @@ abstract class AmazonReportsCore extends AmazonCore{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         $this->urlbranch = '';
-        if(isset($AMAZON_VERSION_REPORTS))
-        $this->options['Version'] = $AMAZON_VERSION_REPORTS;
+        if(isset($AMAZON_VERSION_REPORTS)) {
+            $this->options['Version'] = $AMAZON_VERSION_REPORTS;
+        }
     }
     
     /**

--- a/includes/classes/AmazonSellersCore.php
+++ b/includes/classes/AmazonSellersCore.php
@@ -38,11 +38,7 @@ abstract class AmazonSellersCore extends AmazonCore{
      */
     public function __construct($s, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if(isset($AMAZON_VERSION_SELLERS)){
             $this->urlbranch = 'Sellers/'.$AMAZON_VERSION_SELLERS;

--- a/includes/classes/AmazonServiceStatus.php
+++ b/includes/classes/AmazonServiceStatus.php
@@ -46,11 +46,7 @@ class AmazonServiceStatus extends AmazonCore{
      */
     public function __construct($s, $service = null, $mock = false, $m = null, $config = null){
         parent::__construct($s, $mock, $m, $config);
-        if (file_exists($this->config)){
-            include($this->config);
-        } else {
-            throw new Exception('Config file does not exist!');
-        }
+        include($this->env);
         
         if ($service){
             $this->setService($service);
@@ -58,10 +54,12 @@ class AmazonServiceStatus extends AmazonCore{
         
         $this->options['Action'] = 'GetServiceStatus';
         
-        if(isset($THROTTLE_LIMIT_STATUS))
-        $this->throttleLimit = $THROTTLE_LIMIT_STATUS;
-        if(isset($THROTTLE_TIME_STATUS))
-        $this->throttleTime = $THROTTLE_TIME_STATUS;
+        if(isset($THROTTLE_LIMIT_STATUS)) {
+            $this->throttleLimit = $THROTTLE_LIMIT_STATUS;
+        }
+        if(isset($THROTTLE_TIME_STATUS)) {
+            $this->throttleTime = $THROTTLE_TIME_STATUS;
+        }
         $this->throttleGroup = 'GetServiceStatus';
     }
     
@@ -83,8 +81,8 @@ class AmazonServiceStatus extends AmazonCore{
      * @return boolean <b>TRUE</b> if valid input, <b>FALSE</b> if improper input
      */
     public function setService($s){
-        if (file_exists($this->config)){
-            include($this->config);
+        if (file_exists($this->env)){
+            include($this->env);
         } else {
             return false;
         }


### PR DESCRIPTION
Moved the Amazon API constants (API version number, throttle limits) to separate file so that it no longer requires the user to keep them up to date. This also greatly reduces the number of times the user's store credentials are loaded.

Also finally put curly braces around those single-line if statements.
