### PR TITLE
Product-related bugfixes

### DIFF
--- a/includes/classes/AmazonProduct.php
+++ b/includes/classes/AmazonProduct.php
@@ -142,6 +142,16 @@ class AmazonProduct extends AmazonProductsCore{
                     }
                 }
             }
+            //child relations use namespace but parent does not
+            foreach($xml->Relationships->children('ns2',true) as $x){
+                foreach($x->children() as $y){
+                    foreach($y->children() as $z){
+                        foreach($z->children() as $zzz){
+                            $this->data['Relationships'][$x->getName()][$y->getName()][$z->getName()][$zzz->getName()] = (string)$zzz;
+                        }
+                    }
+                }
+            }
         }
         
         //CompetitivePricing

--- a/includes/classes/AmazonProductInfo.php
+++ b/includes/classes/AmazonProductInfo.php
@@ -84,6 +84,8 @@ class AmazonProductInfo extends AmazonProductsCore{
                 unset($this->options[$op]);
             }
         }
+        //remove Category-specific name
+        unset($this->options['SellerSKU']);
     }
     
     /**
@@ -125,6 +127,8 @@ class AmazonProductInfo extends AmazonProductsCore{
                 unset($this->options[$op]);
             }
         }
+        //remove Category-specific name
+        unset($this->options['ASIN']);
     }
     
     /**
@@ -394,9 +398,11 @@ class AmazonProductInfo extends AmazonProductsCore{
         if (array_key_exists('SellerSKUList.SellerSKU.1',$this->options)){
             $this->options['Action'] = 'GetProductCategoriesForSKU';
             $this->resetASINs();
+            $this->options['SellerSKU'] = $this->options['SellerSKUList.SellerSKU.1'];
         } else if (array_key_exists('ASINList.ASIN.1',$this->options)){
             $this->options['Action'] = 'GetProductCategoriesForASIN';
             $this->resetSKUs();
+            $this->options['ASIN'] = $this->options['ASINList.ASIN.1'];
         }
     }
     


### PR DESCRIPTION
One of the product's actions uses different parameter names from the rest of the actions. The proper parameter names are now used and are removed for the other actions.

Fixed Bug #35. Amazon uses namespace giving product variant children data but not parent data, and I was not checking for namespace.