### PR TITLE
Fixed report sales channel param being sent wrong

### DIFF
--- a/includes/classes/AmazonReportRequest.php
+++ b/includes/classes/AmazonReportRequest.php
@@ -175,9 +175,9 @@ class AmazonReportRequest extends AmazonReportsCore{
      */
     public function setShowSalesChannel($s){
         if ($s == 'true' || (is_bool($s) && $s == true)){
-            $this->options['ReportOptions=ShowSalesChannel'] = 'true';
+            $this->options['ReportOptions'] = 'ShowSalesChannel=true';
         } else if ($s == 'false' || (is_bool($s) && $s == false)){
-            $this->options['ReportOptions=ShowSalesChannel'] = 'false';
+            $this->options['ReportOptions'] = 'ShowSalesChannel=false';
         } else {
             return false;
         }

--- a/test-cases/includes/classes/AmazonReportRequestTest.php
+++ b/test-cases/includes/classes/AmazonReportRequestTest.php
@@ -92,8 +92,8 @@ class AmazonReportRequestTest extends PHPUnit_Framework_TestCase {
         $this->assertNull($this->object->setShowSalesChannel('false'));
         $this->assertNull($this->object->setShowSalesChannel('true'));
         $o = $this->object->getOptions();
-        $this->assertArrayHasKey('ReportOptions=ShowSalesChannel',$o);
-        $this->assertEquals('true',$o['ReportOptions=ShowSalesChannel']);
+        $this->assertArrayHasKey('ReportOptions',$o);
+        $this->assertEquals('ShowSalesChannel=true',$o['ReportOptions']);
     }
     
     public function testSetMarketplaces(){


### PR DESCRIPTION
Fixed a bug found with the sales channel option in the Reports API. The second equals sign needs to be URL-encoded, and thus should be part of the value rather than the key.