### PR TITLE
Order Fixes

### DIFF
--- a/includes/classes/AmazonOrder.php
+++ b/includes/classes/AmazonOrder.php
@@ -801,7 +801,7 @@ class AmazonOrder extends AmazonOrderCore{
      * Returns an indication of whether or not the Order uses the Amazon Prime service.
      *
      * This method will return <b>FALSE</b> if the Prime flag has not been set yet.
-     * @return string|boolean single value, or <b>FALSE</b> if value not set yet
+     * @return string|boolean "true" or "false", or <b>FALSE</b> if value not set yet
      */
     public function getIsPrime(){
         if (isset($this->data['IsPrime'])){

--- a/includes/classes/AmazonOrder.php
+++ b/includes/classes/AmazonOrder.php
@@ -216,8 +216,8 @@ class AmazonOrder extends AmazonOrderCore{
         if (isset($xml->BuyerEmail)){
             $d['BuyerEmail'] = (string)$xml->BuyerEmail;
         }
-        if (isset($xml->ShipServiceLevelCategory)){
-            $d['ShipServiceLevelCategory'] = (string)$xml->ShipServiceLevelCategory;
+        if (isset($xml->ShipmentServiceLevelCategory)){
+            $d['ShipmentServiceLevelCategory'] = (string)$xml->ShipmentServiceLevelCategory;
         }
         if (isset($xml->CbaDisplayableShippingLabel)){
             $d['CbaDisplayableShippingLabel'] = (string)$xml->CbaDisplayableShippingLabel;
@@ -283,7 +283,8 @@ class AmazonOrder extends AmazonOrderCore{
      * <li><b>PaymentMethod</b> (optional) - "COD", "CVS", or "Other"</li>
      * <li><b>BuyerName</b> (optional) - name of the buyer</li>
      * <li><b>BuyerEmail</b> (optional) - Amazon-generated email for the buyer</li>
-     * <li><b>ShipServiceLevelCategory</b> (optional) - "Expedited", "NextDay", "SecondDay", or "Standard"</li>
+     * <li><b>ShipmentServiceLevelCategory</b> (optional) - "Expedited", "FreeEconomy", "NextDay",
+     * "SameDay", "SecondDay", "Scheduled", or "Standard"</li>
      * </ul>
      * @return array|boolean array of data, or <b>FALSE</b> if data not filled yet
      */
@@ -602,18 +603,30 @@ class AmazonOrder extends AmazonOrderCore{
      * Valid values for the service level category are...
      * <ul>
      * <li>Expedited</li>
+     * <li>FreeEconomy</li>
      * <li>NextDay</li>
+     * <li>SameDay</li>
      * <li>SecondDay</li>
+     * <li>Scheduled</li>
      * <li>Standard</li>
      * </ul>
      * @return string|boolean single value, or <b>FALSE</b> if category not set yet
      */
-    public function getShipServiceLevelCategory(){
-        if (isset($this->data['ShipServiceLevelCategory'])){
-            return $this->data['ShipServiceLevelCategory'];
+    public function getShipmentServiceLevelCategory(){
+        if (isset($this->data['ShipmentServiceLevelCategory'])){
+            return $this->data['ShipmentServiceLevelCategory'];
         } else {
             return false;
         }
+    }
+
+    /**
+     * Use getShipmentServiceLevelCategory instead.
+     * @deprecated since version 1.3.0
+     * @return string|boolean single value, or <b>FALSE</b> if category not set yet
+     */
+    public function getShipServiceLevelCategory(){
+        return $this->getShipmentServiceLevelCategory();
     }
     
     /**

--- a/test-cases/includes/classes/AmazonOrderTest.php
+++ b/test-cases/includes/classes/AmazonOrderTest.php
@@ -126,7 +126,7 @@ class AmazonOrderTest extends PHPUnit_Framework_TestCase {
         $x['MarketplaceId'] = 'ATVPDKIKX0DER';
         $x['BuyerName'] = 'Amazon User';
         $x['BuyerEmail'] = '5vlh04mgfmjh9h5@marketplace.amazon.com';
-        $x['ShipServiceLevelCategory'] = 'Standard';
+        $x['ShipmentServiceLevelCategory'] = 'Standard';
         
         $this->assertEquals($x,$get);
         
@@ -348,11 +348,11 @@ class AmazonOrderTest extends PHPUnit_Framework_TestCase {
     /**
      * @depends testFetchOrder
      */
-    public function testGetShipServiceLevelCategory($o){
-        $get = $o->getShipServiceLevelCategory();
+    public function testGetShipmentServiceLevelCategory($o){
+        $get = $o->getShipmentServiceLevelCategory();
         $this->assertEquals('Standard',$get);
         
-        $this->assertFalse($this->object->getShipServiceLevelCategory()); //not fetched yet for this object
+        $this->assertFalse($this->object->getShipmentServiceLevelCategory()); //not fetched yet for this object
     }
     
     /**

--- a/test-cases/mock/fetchOrder.xml
+++ b/test-cases/mock/fetchOrder.xml
@@ -53,7 +53,7 @@
                 <MarketplaceId>ATVPDKIKX0DER</MarketplaceId>
                 <BuyerName>Amazon User</BuyerName>
                 <BuyerEmail>5vlh04mgfmjh9h5@marketplace.amazon.com</BuyerEmail>
-                <ShipServiceLevelCategory>Standard</ShipServiceLevelCategory>
+                <ShipmentServiceLevelCategory>Standard</ShipmentServiceLevelCategory>
                 <OrderTotal>
                     <CurrencyCode>USD</CurrencyCode>
                     <Amount>25.75</Amount>


### PR DESCRIPTION
Fixed the name for the `ShipmentServiceLevelCategory` field and corrected the doc for `getIsPrime`. This will fix #74.