### PR TITLE
Minor New Features and PHP 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "keywords": ["API", "Amazon", "PHP"],
     "require":{
-                "php": "~5.4",
+                "php": ">=5.4",
                 "ext-curl": "*"
     },
     "require-dev": {

--- a/includes/classes/AmazonCore.php
+++ b/includes/classes/AmazonCore.php
@@ -649,6 +649,69 @@ abstract class AmazonCore{
             return false;
         }
     }
+
+    /**
+     * Gives the response code from the last response.
+     * This data can also be found in the array given by getLastResponse.
+     * @return string|int standard REST response code (200, 404, etc.) or <b>NULL</b> if no response
+     * @see getLastResponse
+     */
+    public function getLastResponseCode() {
+        $last = $this->getLastResponse();
+        if (!empty($last['code'])) {
+            return $last['code'];
+        }
+    }
+
+    /**
+     * Gives the last response with an error code.
+     * This may or may not be the same as the last response if multiple requests were made.
+     * @return array associative array of HTTP response or <b>NULL</b> if no error response yet
+     * @see getLastResponse
+     */
+    public function getLastErrorResponse() {
+        if (!empty($this->rawResponses)) {
+            foreach (array_reverse($this->rawResponses) as $x) {
+                if (isset($x['error'])) {
+                    return $x;
+                }
+            }
+        }
+    }
+
+    /**
+     * Gives the Amazon error code from the last error response.
+     * The error code uses words rather than numbers. (Ex: "InvalidParameterValue")
+     * This data can also be found in the XML body given by getLastErrorResponse.
+     * @return string Amazon error code or <b>NULL</b> if not set yet or no error response yet
+     * @see getLastErrorResponse
+     */
+    public function getLastErrorCode() {
+        $last = $this->getLastErrorResponse();
+        if (!empty($last['body'])) {
+            $xml = simplexml_load_string($last['body']);
+            if (isset($xml->Error->Code)) {
+                return $xml->Error->Code;
+            }
+        }
+    }
+
+    /**
+     * Gives the error message from the last error response.
+     * Not all error responses will have error messages.
+     * This data can also be found in the XML body given by getLastErrorResponse.
+     * @return string Amazon error code or <b>NULL</b> if not set yet or no error response yet
+     * @see getLastErrorResponse
+     */
+    public function getLastErrorMessage() {
+        $last = $this->getLastErrorResponse();
+        if (!empty($last['body'])) {
+            $xml = simplexml_load_string($last['body']);
+            if (isset($xml->Error->Message)) {
+                return $xml->Error->Message;
+            }
+        }
+    }
     
     /**
      * Sleeps for the throttle time and records to the log.

--- a/includes/classes/AmazonCore.php
+++ b/includes/classes/AmazonCore.php
@@ -546,17 +546,22 @@ abstract class AmazonCore{
      * The string given is passed through <i>strtotime</i> before being used. The
      * value returned is actually two minutes early, to prevent it from tripping up
      * Amazon. If no time is given, the current time is used.
-     * @param string $time [optional] <p>The time to use. Since this value is
+     * @param string|int $time [optional] <p>The time to use. Since any string values are
      * passed through <i>strtotime</i> first, values such as "-1 hour" are fine.
+     * Unix timestamps are also allowed. Purely numeric values are treated as unix timestamps.
      * Defaults to the current time.</p>
      * @return string Unix timestamp of the time, minus 2 minutes.
+     * @throws InvalidArgumentException
      */
     protected function genTime($time=false){
         if (!$time){
             $time = time();
-        } else {
+        } else if (is_numeric($time)) {
+            $time = (int)$time;
+        } else if (is_string($time)) {
             $time = strtotime($time);
-            
+        } else {
+            throw new InvalidArgumentException('Invalid time input given');
         }
         return date('Y-m-d\TH:i:sO',$time-120);
             

--- a/test-cases/includes/classes/AmazonMerchantServiceListTest.php
+++ b/test-cases/includes/classes/AmazonMerchantServiceListTest.php
@@ -205,7 +205,7 @@ class AmazonMerchantServiceListTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($this->object->setMaxArrivalDate(array(5))); //won't work for this
 
         $check = parseLog();
-        $this->assertEquals('Error: strtotime() expects parameter 1 to be string, array given',$check[1]);
+        $this->assertEquals('Error: Invalid time input given',$check[1]);
     }
 
     public function testSetShipDate(){
@@ -218,7 +218,7 @@ class AmazonMerchantServiceListTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($this->object->setShipDate(array(5))); //won't work for this
 
         $check = parseLog();
-        $this->assertEquals('Error: strtotime() expects parameter 1 to be string, array given',$check[1]);
+        $this->assertEquals('Error: Invalid time input given',$check[1]);
     }
 
     public function testSetDeliveryOption(){

--- a/test-cases/includes/classes/AmazonMerchantShipmentTest.php
+++ b/test-cases/includes/classes/AmazonMerchantShipmentTest.php
@@ -205,7 +205,7 @@ class AmazonMerchantShipmentTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($this->object->setMaxArrivalDate(array(5))); //won't work for this
 
         $check = parseLog();
-        $this->assertEquals('Error: strtotime() expects parameter 1 to be string, array given',$check[1]);
+        $this->assertEquals('Error: Invalid time input given',$check[1]);
     }
 
     public function testSetShipDate(){
@@ -218,7 +218,7 @@ class AmazonMerchantShipmentTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($this->object->setShipDate(array(5))); //won't work for this
 
         $check = parseLog();
-        $this->assertEquals('Error: strtotime() expects parameter 1 to be string, array given',$check[1]);
+        $this->assertEquals('Error: Invalid time input given',$check[1]);
     }
 
     public function testSetDeliveryOption(){

--- a/test-cases/includes/classes/AmazonOrderListTest.php
+++ b/test-cases/includes/classes/AmazonOrderListTest.php
@@ -54,7 +54,7 @@ class AmazonOrderListTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($this->object->setLimits('Created',array(5)));
         $check = parseLog();
         $this->assertEquals('First parameter should be either "Created" or "Modified".',$check[1]);
-        $this->assertEquals('Error: strtotime() expects parameter 1 to be string, array given',$check[2]);
+        $this->assertEquals('Error: Invalid time input given',$check[2]);
     }
     
     public function testSetOrderStatusFilter(){

--- a/test-cases/includes/classes/AmazonShipmentItemListTest.php
+++ b/test-cases/includes/classes/AmazonShipmentItemListTest.php
@@ -57,8 +57,9 @@ class AmazonShipmentItemListTest extends PHPUnit_Framework_TestCase {
     public function timeProvider() {
         return array(
             array(null, null), //nothing given, so no change
-            array(true, true), //not strings or numbers
+            array(time(), time(), 1), //numbers
             array('', ''), //strings, but empty
+            array(0, 0), //numbers, but empty
             array('-1 min', null), //one set
             array(null, '-1 min'), //other set
             array('-1 min', '-1 min'), //both set

--- a/test-cases/includes/classes/AmazonShipmentListTest.php
+++ b/test-cases/includes/classes/AmazonShipmentListTest.php
@@ -72,8 +72,9 @@ class AmazonShipmentListTest extends PHPUnit_Framework_TestCase {
     public function timeProvider() {
         return array(
             array(null, null), //nothing given, so no change
-            array(true, true), //not strings or numbers
+            array(time(), time(), 1), //numbers
             array('', ''), //strings, but empty
+            array(0, 0), //numbers, but empty
             array('-1 min', null), //one set
             array(null, '-1 min'), //other set
             array('-1 min', '-1 min'), //both set


### PR DESCRIPTION
This allows for the library to be installed with newer versions of PHP and adds some features to the core class. The new features include unix timestamp support for `genTime` and new methods for quickly getting information about error responses. While the error data is something that could be retrieved before with `getRawResponses` or `getLastResponse`, these methods offer a quick way to get things like the error code without needing to dig into arrays and XML. Note that in PHP 7, `genTime` will now throw an exception for invalid input rather than an error.

This will fix #64 and was partially inspired by #60.