### PR TITLE
Updated token method to check for MoreResultsAvailable

### DIFF
--- a/includes/classes/AmazonCore.php
+++ b/includes/classes/AmazonCore.php
@@ -737,7 +737,7 @@ abstract class AmazonCore{
         if (!$xml){
             return false;
         }
-        if ($xml->NextToken){
+        if ($xml->NextToken && (string)$xml->HasNext != 'false' && (string)$xml->MoreResultsAvailable != 'false'){
             $this->tokenFlag = true;
             $this->options['NextToken'] = (string)$xml->NextToken;
         } else {

--- a/includes/classes/AmazonReportsCore.php
+++ b/includes/classes/AmazonReportsCore.php
@@ -46,23 +46,5 @@ abstract class AmazonReportsCore extends AmazonCore{
             $this->options['Version'] = $AMAZON_VERSION_REPORTS;
         }
     }
-    
-    /**
-     * Checks for a token and changes the proper options
-     * @param SimpleXMLElement $xml <p>response data</p>
-     * @return boolean <b>FALSE</b> if no XML data
-     */
-    protected function checkToken($xml){
-        if (!$xml){
-            return false;
-        }
-        if ((string)$xml->HasNext == 'true'){
-            $this->tokenFlag = true;
-            $this->options['NextToken'] = (string)$xml->NextToken;
-        } else {
-            unset($this->options['NextToken']);
-            $this->tokenFlag = false;
-        }
-    }
 }
 ?>


### PR DESCRIPTION
Some APIs have a field that indicate token results cannot be retrieved at the current time, and some other APIs don't use "HasNext" when there are results.