### PR TITLE
Add touch to create the logfile if it does not exist

### DIFF
--- a/includes/classes/AmazonCore.php
+++ b/includes/classes/AmazonCore.php
@@ -378,6 +378,10 @@ abstract class AmazonCore{
      * @throws Exception If the file cannot be found or read.
      */
     public function setLogPath($path){
+        if (!file_exists($path)){
+            touch($path);
+        }
+
         if (file_exists($path) && is_readable($path)){
             $this->logpath = $path;
         } else {

--- a/test-cases/includes/classes/AmazonCoreTest.php
+++ b/test-cases/includes/classes/AmazonCoreTest.php
@@ -24,7 +24,11 @@ class AmazonCoreTest extends PHPUnit_Framework_TestCase {
      * This method is called after a test is executed.
      */
     protected function tearDown() {
-        
+        $fileName = 'no-file.log';
+
+        if (file_exists($fileName)){
+            @unlink($fileName);
+        }
     }
 
     /**
@@ -41,7 +45,7 @@ class AmazonCoreTest extends PHPUnit_Framework_TestCase {
             array('no',null, null),
         );
     }
-    
+
     /**
      * @covers AmazonCore::setMock
      * @dataProvider mockProvider
@@ -69,11 +73,22 @@ class AmazonCoreTest extends PHPUnit_Framework_TestCase {
 
     /**
      * @covers AmazonCore::setLogPath
-     * @expectedException Exception
-     * @expectedExceptionMessage Log file does not exist or cannot be read! (no)
      */
     public function testSetLogPath() {
-        $this->object->setLogPath('no');
+        $fileName = 'no-file.log';
+
+        $this->object->setLogPath($fileName);
+
+        $this->assertFileExists($fileName);
+    }
+
+    /**
+     * @covers AmazonCore::setLogPath
+     * @expectedException Exception
+     * @expectedExceptionMessage Log file does not exist or cannot be read! ()
+     */
+    public function testSetLogPathThrowsException() {
+        $this->object->setLogPath(false);
     }
 
     /**
@@ -92,7 +107,7 @@ class AmazonCoreTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('Access Key ID is missing!',$bad[1]);
         $this->assertEquals('Secret Key is missing!',$bad[2]);
     }
-    
+
     public function testGetOptions(){
         $o = $this->object->getOptions();
         $this->assertInternalType('array',$o);
@@ -103,7 +118,7 @@ class AmazonCoreTest extends PHPUnit_Framework_TestCase {
         $this->assertArrayHasKey('SignatureMethod',$o);
         $this->assertArrayHasKey('Version',$o);
     }
-    
+
 }
 
 require_once('helperFunctions.php');


### PR DESCRIPTION
The file is now created when it does not exists instead of causing an blocking error. I think this is a better solution because, if you wanted to migrate to another server you will get a blocking error if you forget to create the file. 