### PR TITLE
Fixed test compatibility with PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ php:
     - '5.5'
     - '5.6'
     - '7'
-script: cd test-cases && phpunit --bootstrap bootstrap.php
+before_script:
+    - wget https://phar.phpunit.de/phpunit-3.7.phar
+script: cd test-cases && php ../phpunit-3.7.phar --bootstrap bootstrap.php


### PR DESCRIPTION
With the release of PHPUnit 6, the PHP7 tests fail in Travis when using the default install of PHPUnit. To get around this, we'll have to force Travis to use the PHPUnit version specified in `composer.json`.