### PR TITLE
Fixed timestamp format to truly follow ISO8601

### DIFF
--- a/includes/classes/AmazonCore.php
+++ b/includes/classes/AmazonCore.php
@@ -568,7 +568,7 @@ abstract class AmazonCore{
         } else {
             throw new InvalidArgumentException('Invalid time input given');
         }
-        return date('Y-m-d\TH:i:sO',$time-120);
+        return date('c', $time-120);
             
     }
     

--- a/test-cases/includes/classes/AmazonFeedListTest.php
+++ b/test-cases/includes/classes/AmazonFeedListTest.php
@@ -124,14 +124,14 @@ class AmazonFeedListTest extends PHPUnit_Framework_TestCase {
         $o = $this->object->getOptions();
         if ($c){
             $this->assertArrayHasKey('SubmittedFromDate',$o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['SubmittedFromDate']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['SubmittedFromDate']);
         } else {
             $this->assertArrayNotHasKey('SubmittedFromDate',$o);
         }
         
         if ($d){
             $this->assertArrayHasKey('SubmittedToDate',$o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['SubmittedToDate']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['SubmittedToDate']);
         } else {
             $this->assertArrayNotHasKey('SubmittedToDate',$o);
         }

--- a/test-cases/includes/classes/AmazonFinancialEventListTest.php
+++ b/test-cases/includes/classes/AmazonFinancialEventListTest.php
@@ -60,7 +60,7 @@ class AmazonFinancialEventListTest extends PHPUnit_Framework_TestCase {
         if ($c) {
             $this->assertNull($try);
             $this->assertArrayHasKey('PostedAfter', $o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i', $o['PostedAfter']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['PostedAfter']);
             $this->assertArrayNotHasKey('AmazonOrderId', $o);
         } else {
             $this->assertFalse($try);
@@ -70,7 +70,7 @@ class AmazonFinancialEventListTest extends PHPUnit_Framework_TestCase {
 
         if ($c && $d) {
             $this->assertArrayHasKey('PostedBefore', $o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i', $o['PostedBefore']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['PostedBefore']);
             //setting only first date resets second one
             $this->assertNull($this->object->setTimeLimits($a));
             $o2 = $this->object->getOptions();

--- a/test-cases/includes/classes/AmazonFinancialGroupListTest.php
+++ b/test-cases/includes/classes/AmazonFinancialGroupListTest.php
@@ -59,7 +59,7 @@ class AmazonFinancialGroupListTest extends PHPUnit_Framework_TestCase {
         if ($c) {
             $this->assertNull($try);
             $this->assertArrayHasKey('FinancialEventGroupStartedAfter', $o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i', $o['FinancialEventGroupStartedAfter']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['FinancialEventGroupStartedAfter']);
         } else {
             $this->assertFalse($try);
             $this->assertArrayNotHasKey('FinancialEventGroupStartedAfter', $o);
@@ -67,7 +67,7 @@ class AmazonFinancialGroupListTest extends PHPUnit_Framework_TestCase {
 
         if ($c && $d) {
             $this->assertArrayHasKey('FinancialEventGroupStartedBefore', $o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i', $o['FinancialEventGroupStartedBefore']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['FinancialEventGroupStartedBefore']);
             //setting only first date resets second one
             $this->assertNull($this->object->setTimeLimits($a));
             $o2 = $this->object->getOptions();

--- a/test-cases/includes/classes/AmazonFulfillmentOrderCreatorTest.php
+++ b/test-cases/includes/classes/AmazonFulfillmentOrderCreatorTest.php
@@ -291,9 +291,9 @@ class AmazonFulfillmentOrderCreatorTest extends PHPUnit_Framework_TestCase {
         $o = $this->object->getOptions();
         if ($c) {
             $this->assertArrayHasKey('DeliveryWindow.StartDateTime', $o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i', $o['DeliveryWindow.StartDateTime']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['DeliveryWindow.StartDateTime']);
             $this->assertArrayHasKey('DeliveryWindow.EndDateTime', $o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i', $o['DeliveryWindow.EndDateTime']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['DeliveryWindow.EndDateTime']);
         } else {
             $this->assertArrayNotHasKey('DeliveryWindow.StartDateTime', $o);
             $this->assertArrayNotHasKey('DeliveryWindow.EndDateTime', $o);

--- a/test-cases/includes/classes/AmazonFulfillmentOrderListTest.php
+++ b/test-cases/includes/classes/AmazonFulfillmentOrderListTest.php
@@ -33,7 +33,7 @@ class AmazonFulfillmentOrderListTest extends PHPUnit_Framework_TestCase {
         $this->assertNull($this->object->setStartTime('-1 min'));
         $o = $this->object->getOptions();
         $this->assertArrayHasKey('QueryStartDateTime',$o);
-        $this->assertNotEquals('1969-12-31T18:58:00-0500',$o['QueryStartDateTime']);
+        $this->assertNotEquals('1969-12-31T18:58:00-05:00', $o['QueryStartDateTime']);
     }
     
     public function testSetUseToken(){

--- a/test-cases/includes/classes/AmazonInventoryListTest.php
+++ b/test-cases/includes/classes/AmazonInventoryListTest.php
@@ -41,7 +41,7 @@ class AmazonInventoryListTest extends PHPUnit_Framework_TestCase {
         $this->assertNull($this->object->setStartTime('-1 min'));
         $o = $this->object->getOptions();
         $this->assertArrayHasKey('QueryStartDateTime',$o);
-        $this->assertNotEquals('1969-12-31T18:58:00-0500',$o['QueryStartDateTime']);
+        $this->assertNotEquals('1969-12-31T18:58:00-05:00', $o['QueryStartDateTime']);
         $this->assertArrayNotHasKey('SellerSkus.member.1',$o);
     }
     

--- a/test-cases/includes/classes/AmazonReportListTest.php
+++ b/test-cases/includes/classes/AmazonReportListTest.php
@@ -137,14 +137,14 @@ class AmazonReportListTest extends PHPUnit_Framework_TestCase {
         $o = $this->object->getOptions();
         if ($c){
             $this->assertArrayHasKey('AvailableFromDate',$o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['AvailableFromDate']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['AvailableFromDate']);
         } else {
             $this->assertArrayNotHasKey('AvailableFromDate',$o);
         }
         
         if ($d){
             $this->assertArrayHasKey('AvailableToDate',$o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['AvailableToDate']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['AvailableToDate']);
         } else {
             $this->assertArrayNotHasKey('AvailableToDate',$o);
         }

--- a/test-cases/includes/classes/AmazonReportRequestListTest.php
+++ b/test-cases/includes/classes/AmazonReportRequestListTest.php
@@ -149,14 +149,14 @@ class AmazonReportRequestListTest extends PHPUnit_Framework_TestCase {
         $o = $this->object->getOptions();
         if ($c){
             $this->assertArrayHasKey('RequestedFromDate',$o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['RequestedFromDate']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['RequestedFromDate']);
         } else {
             $this->assertArrayNotHasKey('RequestedFromDate',$o);
         }
         
         if ($d){
             $this->assertArrayHasKey('RequestedToDate',$o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['RequestedToDate']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['RequestedToDate']);
         } else {
             $this->assertArrayNotHasKey('RequestedToDate',$o);
         }

--- a/test-cases/includes/classes/AmazonReportRequestTest.php
+++ b/test-cases/includes/classes/AmazonReportRequestTest.php
@@ -58,14 +58,14 @@ class AmazonReportRequestTest extends PHPUnit_Framework_TestCase {
         $o = $this->object->getOptions();
         if ($c){
             $this->assertArrayHasKey('StartDate',$o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['StartDate']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['StartDate']);
         } else {
             $this->assertArrayNotHasKey('StartDate',$o);
         }
         
         if ($d){
             $this->assertArrayHasKey('EndDate',$o);
-            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['EndDate']);
+            $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['EndDate']);
         } else {
             $this->assertArrayNotHasKey('EndDate',$o);
         }

--- a/test-cases/includes/classes/AmazonReportScheduleManagerTest.php
+++ b/test-cases/includes/classes/AmazonReportScheduleManagerTest.php
@@ -51,8 +51,8 @@ class AmazonReportScheduleManagerTest extends PHPUnit_Framework_TestCase {
         $this->assertNull($this->object->setScheduledDate('-1 min'));
         $o = $this->object->getOptions();
         $this->assertArrayHasKey('ScheduledDate',$o);
-        $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['ScheduledDate']);
-        $this->assertNotEquals('1969-12-31T18:58:00-0500',$o['ScheduledDate']);
+        $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['ScheduledDate']);
+        $this->assertNotEquals('1969-12-31T18:58:00-05:00', $o['ScheduledDate']);
     }
     
     public function testManageReportSchedule(){

--- a/test-cases/includes/classes/AmazonShipmentItemListTest.php
+++ b/test-cases/includes/classes/AmazonShipmentItemListTest.php
@@ -73,9 +73,9 @@ class AmazonShipmentItemListTest extends PHPUnit_Framework_TestCase {
         $this->object->setTimeLimits($a,$b);
         $o = $this->object->getOptions();
         $this->assertArrayHasKey('LastUpdatedAfter',$o);
-        $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['LastUpdatedAfter']);
+        $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['LastUpdatedAfter']);
         $this->assertArrayHasKey('LastUpdatedBefore',$o);
-        $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['LastUpdatedBefore']);
+        $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['LastUpdatedBefore']);
     }
     
     public function testResetTimeLimit(){

--- a/test-cases/includes/classes/AmazonShipmentListTest.php
+++ b/test-cases/includes/classes/AmazonShipmentListTest.php
@@ -88,9 +88,9 @@ class AmazonShipmentListTest extends PHPUnit_Framework_TestCase {
         $this->object->setTimeLimits($a,$b);
         $o = $this->object->getOptions();
         $this->assertArrayHasKey('LastUpdatedAfter',$o);
-        $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['LastUpdatedAfter']);
+        $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['LastUpdatedAfter']);
         $this->assertArrayHasKey('LastUpdatedBefore',$o);
-        $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i',$o['LastUpdatedBefore']);
+        $this->assertStringMatchesFormat('%d-%d-%dT%d:%d:%d%i:%i', $o['LastUpdatedBefore']);
     }
     
     public function testResetTimeLimit(){


### PR DESCRIPTION
Amazon has decided to get more strict about the format of timestamps, as reported in #153.