### PR TITLE
Set curl timeout to PHP default socket timeout

### DIFF
--- a/includes/classes/AmazonCore.php
+++ b/includes/classes/AmazonCore.php
@@ -782,7 +782,7 @@ abstract class AmazonCore{
         $ch = curl_init();
         
         curl_setopt($ch,CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch,CURLOPT_TIMEOUT, 0);
+        curl_setopt($ch, CURLOPT_TIMEOUT, ini_get('default_socket_timeout'));
         curl_setopt($ch,CURLOPT_FORBID_REUSE, 1);
         curl_setopt($ch,CURLOPT_FRESH_CONNECT, 1);
         curl_setopt($ch,CURLOPT_HEADER, 1);


### PR DESCRIPTION
The recent service outage with Amazon taught us why always setting "0" for the timeout is not a good idea. I want to have this more configurable in the future, but for right now, I am just using PHP's default socket setting.