### PR TITLE
Make response explicit when things go wrong

### DIFF
--- a/includes/classes/AmazonCore.php
+++ b/includes/classes/AmazonCore.php
@@ -336,7 +336,7 @@ abstract class AmazonCore{
      */
     protected function checkResponse($r){
         if (!is_array($r) || !array_key_exists('code', $r)){
-            $this->log("No Response found",'Warning');
+            $this->log("No Response found: ".json_encode($r),'Warning');
             return false;
         }
         if ($r['code'] == 200){


### PR DESCRIPTION
I had an SSL issue and it took me almost one hour to debug it, logs.txt only got "No Response found" text so I had to dig deeper to find the real problem.

Because of the issue above, I wanted to include the response to the log message to let the debugger knows it when they check the logs.

Even if this PR does not get merged maybe it helps other people to catch the issue.